### PR TITLE
회원가입 로직 수정, 토큰 로그인 수정, 식물 정보 생성 구현

### DIFF
--- a/GrowingPetPlant/build.gradle
+++ b/GrowingPetPlant/build.gradle
@@ -27,18 +27,24 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	implementation 'org.springframework.boot:spring-boot-starter-integration'
 	implementation 'org.springframework.integration:spring-integration-mqtt'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	/* lombok */
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	/* jwt & security */
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 	/* Test */
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.mockito:mockito-inline:3.6.0'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.projectlombok:lombok'

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Controller/GraphController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Controller/GraphController.java
@@ -35,8 +35,8 @@ public class GraphController {
 
     // 그래프 디스플레이 api
     @GetMapping("/display")
-    public Graph displayGraph(@RequestParam("date") LocalDate date) {
+    public Graph displayGraph(@RequestParam("userPlantNumber") Long userPlantNumber, @RequestParam("date") LocalDate date) {
 
-        return (graphService.getGraphInfo(date));
+        return (graphService.getGraphInfo(userPlantNumber, date));
     }
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Domain/Graph.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Domain/Graph.java
@@ -63,7 +63,7 @@ public class Graph {
     private UserPlant userPlant;
 
     @Builder
-    public Graph(LocalDate graphDate)
+    public Graph(UserPlant userPlant, LocalDate graphDate)
     {
         this.tempDawn = 0D;
         this.tempMorning = 0D;
@@ -77,7 +77,7 @@ public class Graph {
         this.humiMorning = 0D;
         this.humiDay = 0D;
         this.humiNight = 0D;
+        this.userPlant = userPlant;
         this.graphDate = graphDate;
     }
-
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Service/GraphService.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Service/GraphService.java
@@ -4,6 +4,8 @@ import Happy20.GrowingPetPlant.Graph.Domain.Graph;
 import Happy20.GrowingPetPlant.Graph.Service.Port.GraphRepository;
 import Happy20.GrowingPetPlant.Status.Domain.Status;
 import Happy20.GrowingPetPlant.Status.Service.Port.StatusRepository;
+import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
+import Happy20.GrowingPetPlant.UserPlant.Service.Port.UserPlantRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +21,7 @@ public class GraphService {
 
     private StatusRepository statusRepository;
     private GraphRepository graphRepository;
+    private UserPlantRepository userPlantRepository;
 
     // 0으로 초기화 된 그래프 데이터 생성(초기값)
     public void createGraph(LocalDate date) {
@@ -144,11 +147,13 @@ public class GraphService {
     }
 
     // 그래프 display
-    public Graph getGraphInfo(LocalDate date)
+    public Graph getGraphInfo(Long userPlantNumber, LocalDate date)
     {
+        UserPlant userPlant = userPlantRepository.findByUserPlantNumber(userPlantNumber);
+
         Graph g = graphRepository.findGraphByGraphDate(date);
         if(g == null)
-            return new Graph(date);
+            return new Graph(userPlant, date);
         else
             return (g);
     }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/JwtAuthenticationFilter.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package Happy20.GrowingPetPlant.JWT;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+
+            // 1. Request Header에서 JWT 토큰 추출
+            String accessToken = jwtProvider.resolveAccessToken((HttpServletRequest) request);
+            String refreshToken = jwtProvider.resolveRefreshToken((HttpServletRequest) request);
+            System.out.println("액세스 토큰: " + accessToken);
+            System.out.println("리프레쉬 토큰: " + refreshToken);
+
+            try {
+                // 2. validateToken으로 토큰 유효성 검사
+                if (accessToken != null && jwtProvider.validateAccessToken(accessToken)) {
+                    // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
+                    Authentication authentication = jwtProvider.getAuthentication(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+            catch (ExpiredJwtException e) {
+                // 3. 액세스 토큰이 만료된 경우 리프레쉬 토큰을 통해 액세스 토큰 재발급을 시도한다.
+                if (refreshToken != null && jwtProvider.refreshTokenValidation(refreshToken, e.getClaims().getSubject())) {
+                    String id = e.getClaims().getSubject();
+                    String newAccessToken = jwtProvider.createAccessToken(id);
+                    String newRefreshToken = jwtProvider.createRefreshToken(id);
+                    HttpServletResponse httpResponse = (HttpServletResponse) response;
+                    httpResponse.setHeader("AccessToken", newAccessToken);
+                    httpResponse.setHeader("RefreshToken", newRefreshToken);
+                    System.out.println("액세스 토큰 재발급");
+                    System.out.println(newAccessToken);
+                    System.out.println(newRefreshToken);
+                    SecurityContextHolder.getContext().setAuthentication(jwtProvider.getAuthentication(newAccessToken));
+                    }
+                else {
+                    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid JWT Token");
+                    return;
+                }
+            }
+
+            chain.doFilter(request, response); // 다음 필터로 넘어가거나, 요청 처리 진행
+        }
+}

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/JwtProvider.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/JwtProvider.java
@@ -1,0 +1,200 @@
+package Happy20.GrowingPetPlant.JWT;
+
+import Happy20.GrowingPetPlant.User.Domain.User;
+import Happy20.GrowingPetPlant.User.Service.Port.UserRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+// JWT와 관련된 유틸 기능을 제공
+// 서명에 사용한 Key 값으로 복호화를 진행하기 때문에 동일한 Key 값이 필요
+public class JwtProvider {
+
+    private static final String BEARER_TYPE = "Bearer";
+    private final String PREFIX_REFRESH = "REFRESH:";
+    private final String PREFIX_LOGOUT = "LOGOUT:";
+    private final String PREFIX_LOGOUT_REFRESH = "LOGOUT_REFRESH:";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+    private final StringRedisTemplate redisTemplate;
+    private final UserRepository userRepository;
+
+    private final Key key;
+
+    public JwtProvider(@Value("${jwt.secret}") String secretKey, StringRedisTemplate redisTemplate,
+                       UserRepository userRepository) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.redisTemplate = redisTemplate;
+        this.userRepository = userRepository;
+    }
+
+    public TokenDto generateToken(User loginUser) {
+
+        // Access Token 생성
+        String accessToken = createAccessToken(loginUser.getId());
+
+        // Refresh Token 생성
+        String refreshToken = createRefreshToken(loginUser.getId());
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public String createAccessToken(String id) {
+        long now = (new Date()).getTime();
+        User user = userRepository.findById(id);
+
+        return Jwts.builder()
+                .setSubject(user.getId()) // payload "sub": "name"
+                .claim("auth", user.getAuthority())
+                .setExpiration(new Date(now + ACCESS_TOKEN_EXPIRE_TIME)) // payload "exp": 151621022 (ex)
+                .signWith(key, SignatureAlgorithm.HS256) // header "alg": "HS256"
+                .compact();
+    }
+
+    public String createRefreshToken(String id) {
+        long now = (new Date()).getTime();
+        User loginMember = userRepository.findById(id);
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // redis에 Refresh Token 저장
+        redisTemplate.opsForValue()
+                .set(PREFIX_REFRESH + loginMember.getId(), refreshToken, Duration.ofSeconds(REFRESH_TOKEN_EXPIRE_TIME));
+
+        return refreshToken;
+    }
+
+    // Request Header에서 액세스 토큰 정보 추출
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // Request Header에서 리프레쉬 토큰 정보 추출
+    public String resolveRefreshToken(HttpServletRequest request) {
+        String refreshToken = request.getHeader("RefreshToken");
+        if (StringUtils.hasText(refreshToken)) {
+            return refreshToken;
+        }
+        return null;
+    }
+
+    // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication return
+        // UserDetails: interface, User: UserDetails를 구현한 class
+        UserDetails principal = new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 정보를 검증하는 메서드
+    public boolean validateAccessToken(String token) {
+        try {
+            String id = parseClaims(token).getSubject();
+            String logoutToken = redisTemplate.opsForValue().get(PREFIX_LOGOUT + id);
+
+            System.out.println("제공된 토큰: " + token);
+            System.out.println("로그아웃된 토큰: " + logoutToken);
+
+            if (token.equals(logoutToken)) {
+                System.out.println("로그아웃 처리된 액세스 토큰입니다.");
+                return false;
+            }
+
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+            throw e;
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    // refreshToken 토큰 검증
+    // db에 저장되어 있는 token과 비교
+    // db에 저장한다는 것이 jwt token을 사용한다는 강점을 상쇄시킨다.
+    // db 보다는 redis를 사용하는 것이 더욱 좋다. (in-memory db기 때문에 조회속도가 빠르고 주기적으로 삭제하는 기능이 기본적으로 존재합니다.)
+    public boolean refreshTokenValidation(String token, String id) {
+        String logoutRefresh = redisTemplate.opsForValue().get(PREFIX_LOGOUT_REFRESH + id);
+
+        System.out.println("제공된 토큰: " + token);
+        System.out.println("로그아웃된 토큰: " + logoutRefresh);
+
+        if (token.equals(logoutRefresh)) {
+            System.out.println("로그아웃 처리된 리프레쉬 토큰입니다.");
+            return false;
+        }
+
+        String searchRefresh = redisTemplate.opsForValue().get(PREFIX_REFRESH + id);
+        // DB에 저장한 토큰 비교
+        return token.equals(searchRefresh);
+    }
+
+    // accessToken
+    public Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public boolean confirmLogout(String accessToken, String id) {
+        String logoutToken = redisTemplate.opsForValue().get(PREFIX_LOGOUT + id);
+        return accessToken.equals(logoutToken);
+    }
+}

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/SecurityConfig.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/SecurityConfig.java
@@ -1,0 +1,44 @@
+package Happy20.GrowingPetPlant.JWT;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // REST API이므로 basic auth 및 csrf 보안을 사용하지 않음
+        http.httpBasic(AbstractHttpConfigurer::disable);
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // JWT를 사용하기 때문에 세션을 사용하지 않음
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers("/user/login", "/user/sign-up"
+                ).permitAll()
+                .anyRequest().authenticated())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // BCrypt Encoder 사용
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/SecurityUtil.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/SecurityUtil.java
@@ -1,0 +1,14 @@
+package Happy20.GrowingPetPlant.JWT;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+    public static String getCurrentEmail() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new RuntimeException("No authentication information.");
+        }
+        return authentication.getName();
+    }
+}

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/TokenDto.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/JWT/TokenDto.java
@@ -1,0 +1,16 @@
+package Happy20.GrowingPetPlant.JWT;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenDto {
+    String grantType;
+    String accessToken;
+    String refreshToken;
+}

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Plant/Domain/Plant.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Plant/Domain/Plant.java
@@ -21,9 +21,6 @@ public class Plant {
     @Column(name = "plant_number")
     private Long plantNumber;
 
-    @Column(name = "plant_name")
-    private String plantName;
-
     @Column(name = "plant_type")
     private String plantType;
 
@@ -31,8 +28,7 @@ public class Plant {
     private Long period;
 
     @Builder
-    public Plant(String plantName, String plantType, Long period) {
-        this.plantName = plantName;
+    public Plant(String plantType, Long period) {
         this.plantType = plantType;
         this.period = period;
     }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Plant/PlantRepository.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Plant/PlantRepository.java
@@ -4,5 +4,5 @@ import Happy20.GrowingPetPlant.Plant.Domain.Plant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlantRepository extends JpaRepository<Plant, Long> {
-    Plant findPlantByPlantName(String plantName);
+    Plant findPlantByPlantType(String plantType);
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Domain/Status.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Domain/Status.java
@@ -47,8 +47,19 @@ public class Status {
     @JsonBackReference
     private UserPlant userPlant;
 
-    @Builder
-    //인수없는 생성자 자동으로 생성됨(NoArgsConstructor), 생성자
+    @Builder(builderMethodName = "statusByUserPlantBuilder")
+    public Status(UserPlant userPlant) {
+        this.moisture = 0D;
+        this.temperature = 0D;
+        this.humidity = 0D;
+        this.light = false;
+        this.fan = false;
+        this.watering = null;
+        this.userPlant = userPlant;
+        this.createTime = LocalDateTime.now();
+    }
+
+    @Builder(builderMethodName = "statusByStatusBuilder")
     public Status(Double moisture, Double temperature, Double humidity, Boolean light, Boolean fan,  Boolean watering, UserPlant userPlant) {
         this.moisture = moisture;
         this.temperature = temperature;

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Service/StatusService.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Service/StatusService.java
@@ -25,7 +25,7 @@ public class StatusService {
         UserPlant userPlant = userPlantRepository.findByUserPlantNumber(userPlantNumber);
         Status recentStatus = statusRepository.findRecentStatusByUserPlant(userPlant);
 
-        Status newStatus = Status.builder()
+        Status newStatus = Status.statusByStatusBuilder()
                 .moisture(recentStatus.getMoisture())
                 .temperature(recentStatus.getTemperature())
                 .humidity(recentStatus.getHumidity())

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Authority.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Authority.java
@@ -1,0 +1,5 @@
+package Happy20.GrowingPetPlant.User;
+
+public enum Authority {
+    ROLE_USER, ROLE_ADMIN;
+}

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/DTO/PostSignupReq.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/DTO/PostSignupReq.java
@@ -18,17 +18,17 @@ public class PostSignupReq {
 
     private String phoneNumber;
 
+    private String userPlantName;
+
     private String plantType;
 
-    private String plantName;
-
     @Builder
-    public PostSignupReq(String id, String password, String userName, String phoneNumber, String plantType, String plantName) {
+    public PostSignupReq(String id, String password, String userName, String phoneNumber, String userPlantName, String plantType) {
         this.id = id;
         this.password = password;
         this.userName = userName;
         this.phoneNumber = phoneNumber;
+        this.userPlantName = userPlantName;
         this.plantType = plantType;
-        this.plantName = plantName;
     }
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Domain/User.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Domain/User.java
@@ -1,5 +1,6 @@
 package Happy20.GrowingPetPlant.User.Domain;
 
+import Happy20.GrowingPetPlant.User.Authority;
 import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
@@ -10,6 +11,8 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static Happy20.GrowingPetPlant.User.Authority.ROLE_USER;
 
 @Getter
 @Setter
@@ -50,6 +53,9 @@ public class User {
     @JsonManagedReference
     private List<UserPlant> plantsList = new ArrayList<>();
 
+    @Column(name = "authority")
+    private Authority authority;
+
     @Builder
     //인수없는 생성자 자동으로 생성됨(NoArgsConstructor), 생성자
     public User(String id, String password, String userName, String phoneNumber) {
@@ -57,5 +63,6 @@ public class User {
         this.password = password;
         this.userName = userName;
         this.phoneNumber = phoneNumber;
+        this.authority = ROLE_USER;
     }
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/Port/UserRepository.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/Port/UserRepository.java
@@ -9,6 +9,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUserName(String userName); // 해당 유저명이 DB에 존재하는지 조회
 
+    boolean existsByPhoneNumber(String phoneNumber); // 해당 전화번호가 DB에 존재하는지 조회
+
     User findById(String id); // 아이디로 사용자 조회
 
     User findByUserNumber(Long userNumber); // 유저 번호로 사용자 조회

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Controller/UserPlantController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Controller/UserPlantController.java
@@ -1,25 +1,46 @@
 package Happy20.GrowingPetPlant.UserPlant.Controller;
 
-import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
+import Happy20.GrowingPetPlant.User.Domain.User;
+import Happy20.GrowingPetPlant.User.Service.Port.UserRepository;
+import Happy20.GrowingPetPlant.UserPlant.DTO.PostCreateUserPlantReq;
+import Happy20.GrowingPetPlant.UserPlant.Service.Port.UserPlantRepository;
 import Happy20.GrowingPetPlant.UserPlant.Service.UserPlantService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.http.parser.HttpParser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController
 @RequestMapping("userplant")
+@RequiredArgsConstructor
 public class UserPlantController {
     private final UserPlantService userPlantService;
+    private final UserPlantRepository userPlantRepository;
+    private final UserRepository userRepository;
 
-    @Autowired
-    public UserPlantController(UserPlantService userPlantService){this.userPlantService = userPlantService;}
+    @PostMapping("/add")
+    public ResponseEntity<String> createUserPlant(@RequestBody PostCreateUserPlantReq postCreateUserPlantReq, Authentication principal) {
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+        User user = userRepository.findById(principal.getName()); // 유저 조회
+
+        if (userPlantRepository.existsByUserAndUserPlantName(user, postCreateUserPlantReq.getUserPlantName())) // 유저-식물 이름 중복 예외 처리
+            return ResponseEntity.status(HttpStatus.OK).body("중복된 식물 이름입니다.\n");
+
+        userPlantService.createUserPlant(user, postCreateUserPlantReq.getUserPlantName(), postCreateUserPlantReq.getPlantType()); // 유저-식물 정보 생성
+
+        return ResponseEntity.status(HttpStatus.OK).body("식물 정보를 생성했습니다.\n");
+    }
+
+    @GetMapping("/findAllPlant")
+    public List<Long> findAllPlant() {
+        return userPlantService.findAllPlantNumber();
+    }
 
 //    // 유저번호 -> 식물정보찾기
 //    @GetMapping("/findUserPlant")
@@ -31,9 +52,4 @@ public class UserPlantController {
 //        else
 //            return ResponseEntity.status(HttpStatus.OK).body(userPlant);
 //    }
-
-    @GetMapping("/findAllPlant")
-    public List<Long> findAllPlant() {
-        return userPlantService.findAllPlantNumber();
-    }
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/DTO/PostCreateUserPlantReq.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/DTO/PostCreateUserPlantReq.java
@@ -1,0 +1,19 @@
+package Happy20.GrowingPetPlant.UserPlant.DTO;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PostCreateUserPlantReq {
+    private String userPlantName;
+
+    private String plantType;
+
+    @Builder
+    public PostCreateUserPlantReq(String userPlantName, String plantType) {
+        this.userPlantName = userPlantName;
+        this.plantType = plantType;
+    }
+}

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Domain/UserPlant.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Domain/UserPlant.java
@@ -1,5 +1,6 @@
 package Happy20.GrowingPetPlant.UserPlant.Domain;
 
+import Happy20.GrowingPetPlant.Graph.Domain.Graph;
 import Happy20.GrowingPetPlant.Plant.Domain.Plant;
 import Happy20.GrowingPetPlant.Status.Domain.Status;
 import Happy20.GrowingPetPlant.User.Domain.User;
@@ -28,18 +29,11 @@ public class UserPlant {
     @Column(name = "user_plant_name")
     private String userPlantName;
 
-    @NotBlank(message = "식물 종류를 선택해주세요.")
-    @Column(name = "user_plant_type")
-    private String userPlantType;
-
     @Column(name = "growing_date")
     private LocalDate growingDate;
 
     @Column(name = "watering_date")
     private LocalDate wateringDate;
-
-    @Column(name = "main")
-    private Boolean main;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_number")
@@ -53,12 +47,14 @@ public class UserPlant {
     @JsonManagedReference
     private List<Status> statusList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "userPlant", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
+    private List<Graph> graphList = new ArrayList<>();
+
     @Builder
-    public UserPlant(String userPlantName, String userPlantType, LocalDate wateringDate, Boolean main, User user, Plant plant) {
+    public UserPlant(String userPlantName, LocalDate wateringDate, User user, Plant plant) {
         this.userPlantName = userPlantName;
-        this.userPlantType = userPlantType;
         this.growingDate = LocalDate.now();;
-        this.main = main;
         this.wateringDate = wateringDate;
         this.user = user;
         this.plant = plant;

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/Port/UserPlantRepository.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/Port/UserPlantRepository.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 
 public interface UserPlantRepository extends JpaRepository<UserPlant, Long> {
+    Boolean existsByUserAndUserPlantName(User user, String userPlantName);
+
     List<UserPlant> findAllByUser(User user);
     UserPlant findByUserPlantNumber(Long userPlantNumber);
 

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/UserPlantService.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/UserPlantService.java
@@ -1,8 +1,18 @@
 package Happy20.GrowingPetPlant.UserPlant.Service;
 
+import Happy20.GrowingPetPlant.Graph.Domain.Graph;
+import Happy20.GrowingPetPlant.Graph.Service.Port.GraphRepository;
+import Happy20.GrowingPetPlant.Plant.Domain.Plant;
+import Happy20.GrowingPetPlant.Plant.PlantRepository;
+import Happy20.GrowingPetPlant.Status.Domain.Status;
+import Happy20.GrowingPetPlant.Status.Service.Port.StatusRepository;
+import Happy20.GrowingPetPlant.User.Domain.User;
+import Happy20.GrowingPetPlant.UserPlant.DTO.PostCreateUserPlantReq;
 import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
 import Happy20.GrowingPetPlant.UserPlant.Service.Port.UserPlantRepository;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.pulsar.PulsarProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,18 +20,50 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class UserPlantService {
 
     private final UserPlantRepository userPlantRepository;
+    private final PlantRepository plantRepository;
+    private final StatusRepository statusRepository;
+    private final GraphRepository graphRepository;
+
+    @Transactional
+    public void createUserPlant(User user, String userPlantName, String plantType) {
+        Plant plant = plantRepository.findPlantByPlantType(plantType); // 식물 종 선택
+
+        UserPlant newUserPlant = UserPlant.builder()
+                .userPlantName(userPlantName)
+                .wateringDate(null)
+                .user(user)
+                .plant(plant)
+                .build();
+
+        userPlantRepository.save(newUserPlant); // 식물 정보 생성
+
+        Status newStatus = Status.statusByUserPlantBuilder()
+                .userPlant(newUserPlant)
+                .build();
+
+        statusRepository.save(newStatus); // 상태 정보 생성
+
+        Graph newGraph = Graph.builder()
+                .userPlant(newUserPlant)
+                .graphDate(LocalDate.now())
+                .build();
+
+        graphRepository.save(newGraph); // 그래프 정보 생성
+    }
+
+    @Transactional
+    public List<Long> findAllPlantNumber() {
+        return userPlantRepository.findAllByuserPlant();
+    }
+
 
 //    @Transactional
 //    public UserPlant validateUserPlant(Long userNumber) {
 //        return userPlantRepository.findByUserNumber(userNumber);
 //    }
 
-    @Transactional
-    public List<Long> findAllPlantNumber() {
-        return userPlantRepository.findAllByuserPlant();
-    }
 }

--- a/GrowingPetPlant/src/main/resources/application-jwt.properties
+++ b/GrowingPetPlant/src/main/resources/application-jwt.properties
@@ -1,0 +1,3 @@
+# JWT
+# openssl rand -hex 32
+jwt.secret = 75f753b1d56733c64b2d1cd3dcfce355cb0b71c1e861f18eb55d014a01c33ddc

--- a/GrowingPetPlant/src/main/resources/application.properties
+++ b/GrowingPetPlant/src/main/resources/application.properties
@@ -1,8 +1,8 @@
-spring.profiles.include=mysql
+spring.profiles.include=mysql, mqtt, jwt
 spring.jackson.time-zone=Asia/Seoul
 
 # hibernate
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.hibernate.format_sql=true
 spring.output.ansi.enabled=always


### PR DESCRIPTION
1. 기존 로그인 -> 토큰 로그인
- id 기반으로 토큰 정보 생성
- /user/sign-up, /user/login API만 권한 없이 실행 가능

2. 회원가입 로직 수정
- 회원가입시 회원 정보 검사(아이디, 닉네임, 전화번호 중복 검사)
- 유저-식물, 상태, 그래프 정보 생성

3. 식물 정보 생성 API 구현
- 유저-식물 이름 중복 검사
- 유저-식물, 상태, 그래프 정보 생성