### PR TITLE
스케줄링 및 아두이노 topic 구독 수정

### DIFF
--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Controller/GraphController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Controller/GraphController.java
@@ -15,23 +15,23 @@ public class GraphController {
 
     public GraphController(GraphService graphService) { this.graphService = graphService; }
 
-    // 그래프 정보 생성(다음날로 넘어가는 정각) api
-    // 모든 값 0으로 초기화
-    @PostMapping("/create")
-    public ResponseEntity<String> createGraph(@RequestParam("date") LocalDate date) {
-        graphService.createGraph(date);
-        return ResponseEntity.status(HttpStatus.OK).body("그래프 정보를 생성했습니다.");
-    }
-
-    // 그래프 정보 수정(6시간 단위) api
-    @PatchMapping("/update")
-    public ResponseEntity<String> modifyGraph(@RequestParam("date") LocalDate date) {
-        if (graphService.updateGraph(date))
-            return ResponseEntity.status(HttpStatus.OK).body("그래프 정보를 수정했습니다.");
-        else
-            return ResponseEntity.status(HttpStatus.OK).body("그래프 정보 수정에 실패했습니다.");
-
-    }
+//    // 그래프 정보 생성(다음날로 넘어가는 정각) api
+//    // 모든 값 0으로 초기화
+//    @PostMapping("/create")
+//    public ResponseEntity<String> createGraph(@RequestParam("date") LocalDate date) {
+//        graphService.createGraph(date);
+//        return ResponseEntity.status(HttpStatus.OK).body("그래프 정보를 생성했습니다.");
+//    }
+//
+//    // 그래프 정보 수정(6시간 단위) api
+//    @PatchMapping("/update")
+//    public ResponseEntity<String> modifyGraph(@RequestParam("date") LocalDate date) {
+//        if (graphService.updateGraph(date))
+//            return ResponseEntity.status(HttpStatus.OK).body("그래프 정보를 수정했습니다.");
+//        else
+//            return ResponseEntity.status(HttpStatus.OK).body("그래프 정보 수정에 실패했습니다.");
+//
+//    }
 
     // 그래프 디스플레이 api
     @GetMapping("/display")

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Service/Port/GraphRepository.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Graph/Service/Port/GraphRepository.java
@@ -1,10 +1,16 @@
 package Happy20.GrowingPetPlant.Graph.Service.Port;
 
 import Happy20.GrowingPetPlant.Graph.Domain.Graph;
+import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface GraphRepository extends JpaRepository<Graph, Long> {
-    Graph findGraphByGraphDate(LocalDate graphDate); // 그래프 날짜로 그래프 조회
+    // 그래프 날짜로 그래프 조회
+    Graph findGraphByGraphDate(LocalDate date);
+
+    // 유저-식물 번호, 그래프 일자로 그래프 조회
+    Graph findGraphByUserPlantAndGraphDate(UserPlant userPlant, LocalDate date);
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Controller/StatusController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Controller/StatusController.java
@@ -21,11 +21,11 @@ public class StatusController {
     }
 
     // 식물 상태 정각 생성(1시간) api
-    @PostMapping("/create")
-    public ResponseEntity<String> createStatus(@RequestParam("plantNumber") Long plantNumber) {
-        statusService.createStatus(plantNumber);
-        return ResponseEntity.status(HttpStatus.OK).body("상태를 생성했습니다.");
-    }
+//    @PostMapping("/create")
+//    public ResponseEntity<String> createStatus(@RequestParam("plantNumber") Long plantNumber) {
+//        statusService.createStatus(plantNumber);
+//        return ResponseEntity.status(HttpStatus.OK).body("상태를 생성했습니다.");
+//    }
 
     // 식물 최근 온도 확인 api
     @GetMapping("/temp")

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Service/Port/StatusRepository.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Status/Service/Port/StatusRepository.java
@@ -25,4 +25,6 @@ public interface StatusRepository extends JpaRepository<Status, Long> {
     @Query("SELECT s FROM Status s WHERE s.createTime BETWEEN :start AND :end")
     List<Status> findAllByStatusCreateTimeBetween(        @Param("start") LocalDateTime start,
                                                           @Param("end") LocalDateTime end);
+
+    List<Status> findAllByUserPlantAndCreateTimeBetween(UserPlant userPlant, LocalDateTime start, LocalDateTime end);
 }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Subscribe/Subscriber.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/Subscribe/Subscriber.java
@@ -1,10 +1,13 @@
 package Happy20.GrowingPetPlant.Subscribe;
 
+import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
+import Happy20.GrowingPetPlant.UserPlant.Service.Port.UserPlantRepository;
 import org.eclipse.paho.client.mqttv3.*;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -18,14 +21,14 @@ public class Subscriber {
     private MqttClient client;
     private MqttConnectOptions connOpts;
 
-//    @Value("${spring.datasource.url")
-    private String DB_URL = "jdbc:mysql://34.64.63.166/GPP?serverTimezone=Asia/Seoul&characterEncoding=UTF-8";
+    @Value("${spring.datasource.url")
+    private String DB_URL;
 
-//    @Value("${spring.datasource.username}")
-    private String DB_USER = "root";
+    @Value("${spring.datasource.username}")
+    private String DB_USER;
 
-//    @Value("${spring.datasource.password}")
-    private String DB_PASSWORD = "Mysql2020!";
+    @Value("${spring.datasource.password}")
+    private String DB_PASSWORD;
 
     // Private 생성자로 외부에서 인스턴스 생성을 막음
     private Subscriber() {}
@@ -83,15 +86,17 @@ public class Subscriber {
     }
 
     // 데이터베이스에 데이터 삽입 메서드
-    public void insertToDatabase(String tempPayload, String humiPayload, String soilPayload) {
+    public void insertToDatabase(Long userPlantId, String tempPayload, String humiPayload, String soilPayload) {
         try (Connection conn = DriverManager.getConnection(DB_URL, DB_USER, DB_PASSWORD)) {
+
             // 데이터를 삽입할 테이블 이름
-            String query = "UPDATE status SET temperature = ?, humidity = ?, moisture = ? WHERE plant_number = 1 ORDER BY status_number DESC LIMIT 1";
+            String query = "UPDATE status SET temperature = ?, humidity = ?, moisture = ? WHERE user_plant_number = ? ORDER BY status_number DESC LIMIT 1";
             try (PreparedStatement pstmt = conn.prepareStatement(query)) {
                 // 각 토픽의 값을 쿼리에 설정
-                pstmt.setString(1, tempPayload);
-                pstmt.setString(2, humiPayload);
-                pstmt.setString(3, soilPayload);
+                pstmt.setDouble(1, Double.parseDouble(tempPayload));
+                pstmt.setDouble(2, Double.parseDouble(humiPayload));
+                pstmt.setDouble(3, Double.parseDouble(soilPayload));
+                pstmt.setLong(4, userPlantId);
                 pstmt.executeUpdate();
             }
         } catch (SQLException e) {

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
         User user = userRepository.findById(postLoginReq.getId());
 
         if (user == null)
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new PostLoginRes("잘못된 유저 정보입니다.\n", null));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new PostLoginRes(null, "잘못된 유저 정보입니다.\n", null));
         else
             return ResponseEntity.status(HttpStatus.OK).body(userService.validationLogin(user, postLoginReq.getPassword(), response));
     }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/DTO/PostLoginRes.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/DTO/PostLoginRes.java
@@ -8,12 +8,15 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class PostLoginRes {
+    Long userId;
+
     String message;
 
     TokenDto token;
 
     @Builder
-    public PostLoginRes(String message, TokenDto token) {
+    public PostLoginRes(Long userId, String message, TokenDto token) {
+        this.userId = userId;
         this.message = message;
         this.token = token;
     }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/UserService.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/UserService.java
@@ -70,10 +70,10 @@ public class UserService {
         if (passwordEncoder.matches(password, user.getPassword())) {
             // 토큰 생성 및 헤더에 토큰 정보 추가
             TokenDto token = setTokenInHeader(user, response);
-            return (new PostLoginRes("로그인에 성공했습니다.\n", token));
+            return (new PostLoginRes(user.getUserNumber(),"로그인에 성공했습니다.\n", token));
         }
         else
-            return (new PostLoginRes("잘못된 비밀번호입니다.\n", null));
+            return (new PostLoginRes(null, "잘못된 비밀번호입니다.\n", null));
     }
 
     // 유효한 유저인지 확인

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/Port/UserPlantRepository.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/Port/UserPlantRepository.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 public interface UserPlantRepository extends JpaRepository<UserPlant, Long> {
     Boolean existsByUserAndUserPlantName(User user, String userPlantName);
-
     List<UserPlant> findAllByUser(User user);
     UserPlant findByUserPlantNumber(Long userPlantNumber);
 


### PR DESCRIPTION
1. Status 및 Graph 스케줄링
기존 : GCP 상에서 CloudFunction으로 실행했기 때문에 API 필요
현재 : SpringBoot 상에서 스케줄링을 통해 Service단에서 실행

Status 1시간 단위 생성
-> 1시간 마다 각 유저-식물 리스트를 불러와 각각의 상태 정보 생성

Graph 매일 생성
-> 0시에 각 유저-식물 리스트를 불러와 그래프 정보 생성

Graph 6시간 단위로 갱신
-> 6, 12, 18, 24시에 각 유저-식물 리스트를 불러와 그래프 정보 갱신
-> 각각을 4개의 함수로 구현해 간소화

GCP 서버에 배포해둬서 제대로 실행되는지 확인 필요!

2. 아두이노 Topic 구독 수정
유저당 육성 가능한 식물의 수를 늘려 기존 아두이노 구독 관련 코드 수정 필요 !

구독하는 토픽을 아래처럼 수정, + : 와일드 카드 처리한 것으로 모든 유저-식물 관련 토픽을 구독하겠다는 뜻
subscriber.subscribe("userPlant/+/temperature", 0);
subscriber.subscribe("userPlant/+/humidity", 0);
subscriber.subscribe("userPlant/+/moisture", 0);

슬래시 단위로 토픽을 쪼개 유저 식물 번호와 어떤 정보 관련 토픽인지 구분한 후 insertDatabase를 통해 DB를 갱신해준다.