### PR TITLE
로그인시 유저 번호 리턴 삭제

### DIFF
--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
         User user = userRepository.findById(postLoginReq.getId());
 
         if (user == null)
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new PostLoginRes(null, "잘못된 유저 정보입니다.\n", null));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new PostLoginRes("잘못된 유저 정보입니다.\n", null));
         else
             return ResponseEntity.status(HttpStatus.OK).body(userService.validationLogin(user, postLoginReq.getPassword(), response));
     }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/DTO/PostLoginRes.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/DTO/PostLoginRes.java
@@ -8,15 +8,12 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class PostLoginRes {
-    Long userId;
-
     String message;
 
     TokenDto token;
 
     @Builder
-    public PostLoginRes(Long userId, String message, TokenDto token) {
-        this.userId = userId;
+    public PostLoginRes(String message, TokenDto token) {
         this.message = message;
         this.token = token;
     }

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/UserService.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/UserService.java
@@ -70,10 +70,10 @@ public class UserService {
         if (passwordEncoder.matches(password, user.getPassword())) {
             // 토큰 생성 및 헤더에 토큰 정보 추가
             TokenDto token = setTokenInHeader(user, response);
-            return (new PostLoginRes(user.getUserNumber(),"로그인에 성공했습니다.\n", token));
+            return (new PostLoginRes("로그인에 성공했습니다.\n", token));
         }
         else
-            return (new PostLoginRes(null, "잘못된 비밀번호입니다.\n", null));
+            return (new PostLoginRes("잘못된 비밀번호입니다.\n", null));
     }
 
     // 유효한 유저인지 확인


### PR DESCRIPTION
로그인 시 유저 번호 리턴 삭제

Why? 모든 정보를 가져올 때 권한을 인증받게 하기 위해

어떤 방식이 더 토큰 로그인의 의도 및 구조를 따라 작성하는 것인지는 아직 불분명하다..