### PR TITLE
홈 화면 정보 API 수정 - 리스트

### DIFF
--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
@@ -1,12 +1,10 @@
 package Happy20.GrowingPetPlant.User.Controller;
 
-import Happy20.GrowingPetPlant.Status.Domain.Status;
 import Happy20.GrowingPetPlant.Status.Service.Port.StatusRepository;
 import Happy20.GrowingPetPlant.User.DTO.*;
 import Happy20.GrowingPetPlant.User.Service.Port.UserRepository;
 import Happy20.GrowingPetPlant.User.Service.UserService;
 import Happy20.GrowingPetPlant.User.Domain.User;
-import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
 import Happy20.GrowingPetPlant.UserPlant.Service.Port.UserPlantRepository;
 import Happy20.GrowingPetPlant.UserPlant.Service.UserPlantService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,6 +17,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RestController
 @RequestMapping("user")
 @RequiredArgsConstructor
@@ -27,8 +28,6 @@ public class UserController {
     private final UserService userService;
     private final UserRepository userRepository;
     private final UserPlantService userPlantService;
-    private final UserPlantRepository userPlantRepository;
-    private final StatusRepository statusRepository;
 
     // 회원가입 api
     @PostMapping("/sign-up")
@@ -83,11 +82,13 @@ public class UserController {
 
     // 홈 화면 정보 api
     @GetMapping("/home")
-    public ResponseEntity<GetHomeInfoRes> homeInfo(Authentication principal) {
-        if (principal == null)
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new GetHomeInfoRes("잘못된 유저 정보입니다.\n"));
-
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(userService.getHomeInfo(principal.getName()));
+    public ResponseEntity<List<GetHomeInfoRes>> homeInfo(Authentication principal) {
+        List<GetHomeInfoRes> homeInfoResList = new ArrayList<>();
+        if (principal == null) {
+            homeInfoResList.add(new GetHomeInfoRes("잘못된 유저 정보입니다.\n"));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(homeInfoResList);
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getHomeInfo(principal.getName(), homeInfoResList));
     }
 
     // 마이페이지 수정 api

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/UserService.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Service/UserService.java
@@ -85,13 +85,18 @@ public class UserService {
 
     // 홈 화면 정보 리턴
     @Transactional
-    public GetHomeInfoRes getHomeInfo(String id) {
+    public List<GetHomeInfoRes> getHomeInfo(String id, List<GetHomeInfoRes> getHomeInfoResList) {
         User user = userRepository.findById(id);
-        UserPlant userPlant = userPlantRepository.findFirstByUserOrderByUserPlantNumberAsc(user);
-        Status status = statusRepository.findFirstByUserPlantOrderByStatusNumberDesc(userPlant);
+        List<UserPlant> userPlantList = userPlantRepository.findAllByUser(user);
 
-        return (new GetHomeInfoRes("유저 홈 화면 정보입니다.\n", user.getUserNumber(), userPlant.getUserPlantNumber(),
-                userPlant.getUserPlantName(), status.getMoisture(), status.getHumidity(), status.getTemperature()));
+        for (UserPlant userPlant : userPlantList)
+        {
+            Status status = statusRepository.findFirstByUserPlantOrderByStatusNumberDesc(userPlant);
+            getHomeInfoResList.add(new GetHomeInfoRes(user.getUserName() + " 유저 홈 화면 정보입니다.\n", user.getUserNumber(),
+                    userPlant.getUserPlantNumber(), userPlant.getUserPlantName(), status.getMoisture(), status.getHumidity(), status.getTemperature()));
+        }
+
+        return (getHomeInfoResList);
     }
 
     // 유효한 유저인지 확인


### PR DESCRIPTION
홈 화면 정보 API 수정 -> 리스트로 리턴하도록

Why? 유저가 여러 식물 키울 수 있도록 프로젝트를 수정하면서 여러 홈 화면을 다룰 필요가 있어졌다.

 {
        "message": "seojkim 유저 홈 화면 정보입니다.\n",
        "userNumber": 1,
        "userPlantNumber": 1,
        "userPlantName": "바니바니당근당근",
        "moisture": 0.0,
        "humidity": 0.0,
        "temperature": 0.0
    },
    {
        "message": "seojkim 유저 홈 화면 정보입니다.\n",
        "userNumber": 1,
        "userPlantNumber": 2,
        "userPlantName": "저는 맛 없는 오이랍니다.",
        "moisture": 0.0,
        "humidity": 0.0,
        "temperature": 0.0
    },
    {
        "message": "seojkim 유저 홈 화면 정보입니다.\n",
        "userNumber": 1,
        "userPlantNumber": 4,
        "userPlantName": "아츄 널 보면 재채기가 나올 거 같아",
        "moisture": 0.0,
        "humidity": 0.0,
        "temperature": 0.0
    }
...

위처럼 리턴되어진다.