### PR TITLE
유저 식물 정보 삭제 API 구현

### DIFF
--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Controller/UserPlantController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Controller/UserPlantController.java
@@ -3,10 +3,10 @@ package Happy20.GrowingPetPlant.UserPlant.Controller;
 import Happy20.GrowingPetPlant.User.Domain.User;
 import Happy20.GrowingPetPlant.User.Service.Port.UserRepository;
 import Happy20.GrowingPetPlant.UserPlant.DTO.PostCreateUserPlantReq;
+import Happy20.GrowingPetPlant.UserPlant.Domain.UserPlant;
 import Happy20.GrowingPetPlant.UserPlant.Service.Port.UserPlantRepository;
 import Happy20.GrowingPetPlant.UserPlant.Service.UserPlantService;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.http.parser.HttpParser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -30,16 +30,28 @@ public class UserPlantController {
         User user = userRepository.findById(principal.getName()); // 유저 조회
 
         if (userPlantRepository.existsByUserAndUserPlantName(user, postCreateUserPlantReq.getUserPlantName())) // 유저-식물 이름 중복 예외 처리
-            return ResponseEntity.status(HttpStatus.OK).body("중복된 식물 이름입니다.\n");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("중복된 식물 이름입니다.\n");
 
         userPlantService.createUserPlant(user, postCreateUserPlantReq.getUserPlantName(), postCreateUserPlantReq.getPlantType()); // 유저-식물 정보 생성
 
-        return ResponseEntity.status(HttpStatus.OK).body("식물 정보를 생성했습니다.\n");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body("식물 정보를 생성했습니다.\n");
     }
 
     @GetMapping("/findAllPlant")
     public List<Long> findAllPlant() {
         return userPlantService.findAllPlantNumber();
+    }
+
+    @DeleteMapping("/delete/{userPlantNumber}")
+    public ResponseEntity<String> deleteUserPlant(@PathVariable("userPlantNumber") Long userPlantNumber, Authentication principal)
+    {
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("잘못된 유저 정보입니다.\n");
+
+        if (userPlantService.deletePlant(userPlantNumber))
+            return ResponseEntity.status(HttpStatus.OK).body("유저 식물 정보가 삭제되었습니다.\n");
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body("존재하지 않는 식물 정보입니다.\n");
     }
 
 //    // 유저번호 -> 식물정보찾기

--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/UserPlantService.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/UserPlant/Service/UserPlantService.java
@@ -13,6 +13,8 @@ import Happy20.GrowingPetPlant.UserPlant.Service.Port.UserPlantRepository;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.pulsar.PulsarProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,6 +63,17 @@ public class UserPlantService {
     }
 
 
+    @Transactional
+    public Boolean deletePlant(Long userPlantNumber)
+    {
+        UserPlant userPlant = userPlantRepository.findByUserPlantNumber(userPlantNumber);
+        if (userPlant == null)
+            return (false);
+
+        userPlantRepository.delete(userPlant);
+
+        return (true);
+    }
 //    @Transactional
 //    public UserPlant validateUserPlant(Long userNumber) {
 //        return userPlantRepository.findByUserNumber(userNumber);


### PR DESCRIPTION
유저 식물 정보 삭제 API 구현

Path Variable로 삭제할 유저 식물 번호를 받아와 간단히 userPlantRepository의 delete를 활용해 삭제해주었다.

굉장히 단순한 로직이라 금방 마칠 줄 알았는데 Postman을 통해 확인해보니 Path Variable name을 제대로 인식하지 못하는 에러가 존재했다. 구글링을 통해 문제를 해결했다.

해당 블로그를 참조했다.
[https://velog.io/@betaa06/PathVariable-name-%EC%83%9D%EB%9E%B5%EC%8B%9C-%EC%97%90%EB%9F%AC](url)