### PR TITLE
로그아웃 API 수정 -토큰 로그인 반영

### DIFF
--- a/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
+++ b/GrowingPetPlant/src/main/java/Happy20/GrowingPetPlant/User/Controller/UserController.java
@@ -80,6 +80,25 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.OK).body(userService.validationLogin(user, postLoginReq.getPassword(), response));
     }
 
+    // 로그아웃 api
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(Authentication principal, HttpServletRequest request) {
+
+        if (principal == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("잘못된 유저 정보입니다.\n");
+
+        userService.logoutMember(request, principal.getName());
+
+        return ResponseEntity.status(HttpStatus.OK).body("로그아웃 처리되었습니다.\n");
+    }
+
+    // 회원 탈퇴 api
+    @DeleteMapping("/delete/{id}")
+    public String deleteUser(@PathVariable String id){
+        userService.deleteUser(id);
+        return id+ " 사용자 탈퇴가 완료되었습니다.";
+    }
+
     // 홈 화면 정보 api
     @GetMapping("/home")
     public ResponseEntity<List<GetHomeInfoRes>> homeInfo(Authentication principal) {
@@ -131,22 +150,5 @@ public class UserController {
                     "사용자의 비밀번호는\n [" + userPwd + "] 입니다.");
         else
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("존재하지 않는 사용자입니다.");
-    }
-
-    // 로그아웃 api
-    @GetMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletRequest request){
-        //세션 무효화
-        request.getSession().invalidate();
-
-        //클라이언트에게 로그아웃 성공 메시지와 HTTP 상태 코드 반환
-        return new ResponseEntity<>("로그아웃 되었습니다", HttpStatus.OK);
-    }
-
-    // 회원 탈퇴 api
-    @DeleteMapping("/delete/{id}")
-    public String deleteUser(@PathVariable String id){
-        userService.deleteUser(id);
-        return id+ " 사용자 탈퇴가 완료되었습니다.";
     }
 }


### PR DESCRIPTION
로그아웃 API 수정 - jwt 토큰 로그인 방식 반영

기존의 세션 로그인 방식에서 jwt 토큰 블랙리스트 처리를 통한 로그아웃 로직으로 변경하였습니다.

로그인 정보를 바탕으로 해당 액세스 토큰 및 리프레쉬 토큰을 redis 상에 LOGOUT, LOGOUT_REFRESH 태그를 통해
남은 만료기한 동안 블랙리스트 처리를 해 동일 토큰으로 로그인 권한이 필요한 api 실행시 실행되지 않도록 처리했습니다.

테스트 과정에서 제대로 토큰이 인식되지 않는 에러가 있었으나 포스트맨 스크립트 상에서 리프레쉬 토큰을 제대로 추출하지 못하는 
문제임을 확인하고, 수정해 해결했습니다:)